### PR TITLE
Fix #11 & #12

### DIFF
--- a/MsCrmTools.UserSettingsUtility/MainControl.cs
+++ b/MsCrmTools.UserSettingsUtility/MainControl.cs
@@ -391,7 +391,7 @@ namespace MsCrmTools.UserSettingsUtility
                 cbbCurrencies.SelectedItem = cbbCurrencies.Items
                     .Cast<object>()
                     .Skip(1)
-                    .Single(x => ((Entity) x).Id == settings.GetAttributeValue<EntityReference>(UserSettings.TransactionCurrencyId).Id);
+                    .Single(x => ((EntityReference) x).Id == settings.GetAttributeValue<EntityReference>(UserSettings.TransactionCurrencyId).Id);
             }
             else
             {
@@ -419,7 +419,11 @@ namespace MsCrmTools.UserSettingsUtility
                 : 0;
             if (settings.GetAttributeValue<Guid?>(UserSettings.DefaultDashboardId).HasValue)
             {
-                cbbDefaultDashboard.SelectedItem = cbbDefaultDashboard.Items.Cast<object>().Skip(1).Single(x => ((EntityReference)x).Id == settings.GetAttributeValue<Guid?>(UserSettings.DefaultDashboardId));
+                var defaultSystemDashboardId = cbbDefaultDashboard.Items.Cast<object>()
+                    .Skip(1)
+                    .SingleOrDefault(x => ((EntityReference) x).Id ==
+                                 settings.GetAttributeValue<Guid?>(UserSettings.DefaultDashboardId));
+                cbbDefaultDashboard.SelectedItem = defaultSystemDashboardId ?? 0;
             }
             else
             {


### PR DESCRIPTION
1. When I removed strongly typed from the code, I caused type cast exception by mistake. 😞 
2. Handle scenario when user has set a personal dashboard as default dashboard. In this case displaying current setting cause error, as personal dashboards are not populated in the combo box at all.