### PR TITLE
Simple (maybe crude) fix for the issue #17

### DIFF
--- a/MsCrmTools.UserSettingsUtility/MainControl.cs
+++ b/MsCrmTools.UserSettingsUtility/MainControl.cs
@@ -304,8 +304,13 @@ namespace MsCrmTools.UserSettingsUtility
 
                     foreach (var updateUserSetting in updateUserSettings.Item1)
                     {
+                        string errMsg;
                         bw.ReportProgress(0, "Updating settings for user " + updateUserSetting.GetAttributeValue<string>("fullname"));
-                        ush.UpdateSettings(updateUserSetting.Id, updateUserSettings.Item2);
+                        ush.UpdateSettings(updateUserSetting.Id, updateUserSettings.Item2, out errMsg);
+                        if (!string.IsNullOrEmpty(errMsg))
+                        {                            
+                            bw.ReportProgress(10, "Error whilst updating settings for user " + updateUserSetting.GetAttributeValue<string>("fullname") + " - " + errMsg);
+                        }
                     }
                 },
                 PostWorkCallBack = evt =>

--- a/MsCrmTools.UserSettingsUtility/MsCrmTools.UserSettingsUtility.csproj
+++ b/MsCrmTools.UserSettingsUtility/MsCrmTools.UserSettingsUtility.csproj
@@ -197,7 +197,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties BuildVersion_ConfigurationName="Release" BuildVersion_UpdateFileVersion="True" BuildVersion_UpdateAssemblyVersion="True" BuildVersion_BuildVersioningStyle="None.YearStamp.MonthStamp.DayStamp" />
+      <UserProperties BuildVersion_BuildVersioningStyle="None.YearStamp.MonthStamp.DayStamp" BuildVersion_UpdateAssemblyVersion="True" BuildVersion_UpdateFileVersion="True" BuildVersion_ConfigurationName="Release" />
     </VisualStudio>
   </ProjectExtensions>
   <PropertyGroup>


### PR DESCRIPTION
I was seeing an issue (exception thrown) when updating lists of users. The exception complained that the user had no roles in CRM. I've modified the code to catch the error, which does the job, but is maybe a little crude. I couldn't understand why the lack of a role should cause an error when retieving the user settings for that user on line:

` var records = detail.ServiceClient.OrganizationServiceProxy.RetrieveMultiple(new QueryByAttribute("usersettings")`

A better fix would be to ensure this call does not fail for users with no roles assigned in CRM.

Anyway - the amended code worked for me, and allowed me to finish the job at hand. Updating 400 users to be in the right time zone :)
