### PR TITLE
Updated RetrieveDashboards method to include Power BI Dashboards

### DIFF
--- a/MsCrmTools.UserSettingsUtility/AppCode/UserSettingsHelper.cs
+++ b/MsCrmTools.UserSettingsUtility/AppCode/UserSettingsHelper.cs
@@ -57,6 +57,7 @@ namespace MsCrmTools.UserSettingsUtility.AppCode
                 <filter type='or'>
                   <condition attribute='type' operator='eq' value='0' />
                   <condition attribute='type' operator='eq' value='10' />
+                  <condition attribute='type' operator='eq' value='103' />
                 </filter>
                 <order attribute='name' />
               </entity>


### PR DESCRIPTION
Power BI Dashboards in model-driven apps can be set as default dashboards for users, but the User Settings tool does not include them, as the backend query specifically excludes them. This simple fix just adds the correct type code (103) to the query.

https://learn.microsoft.com/en-us/power-apps/developer/data-platform/reference/entities/systemform#BKMK_Type